### PR TITLE
chore: update cloudbuild subs, imgs and opts

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,3 +14,8 @@ steps:
   #      https://docs.sigstore.dev/signing/overview/#on-google-cloud-platform
 substitutions:
   _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'main'
+images:
+  - 'gcr.io/$PROJECT_ID/verify-conformance:$_GIT_TAG'
+options:
+  substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION
- add _PULL_BASE_REF to attempt to resolve build error: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-verify-conformance-push-images/1823830284701798400
- add images to expect to find an image
- set loose on substitution options