### PR TITLE
chore: update to latest ko in cloudbuild

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -14,3 +14,4 @@ builds:
 
 defaultPlatforms:
   - linux/amd64
+  - linux/arm64

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   # NOTE this image comes with Go which may
   #      end up not matching the version required
   #      in go.mod
-  - name: ghcr.io/ko-build/ko:v0.15.1
+  - name: ghcr.io/ko-build/ko:v0.16.0
     entrypoint: /bin/sh
     args:
       - -c


### PR DESCRIPTION
ko v1.16.0 has Go v1.22 in the image, which is matching the version of Go for this program

ko/go build error
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-verify-conformance-push-images/1823835318470578176#1:build-log.txt%3A66

```
🐚(2) podman run -it --rm --entrypoint /usr/local/go/bin/go ghcr.io/ko-build/ko:v0.16.0 version
go version go1.22.5 linux/arm64
```