### PR TITLE
chore: use ko with --bare in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
       - -c
       - |
         export KO_DOCKER_REPO=gcr.io/$PROJECT_ID/verify-conformance
-        ko build --base-import-paths --tags $_GIT_TAG .
+        ko build --bare --tags $_GIT_TAG .
   # TODO sign image with OIDC
   #      https://docs.sigstore.dev/signing/overview/#on-google-cloud-platform
 substitutions:


### PR DESCRIPTION
push to gcr.io/$PROJECT_ID/verify-conformance without sub packages

to resolve
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-verify-conformance-push-images/1823838841958567936#1:build-log.txt%3A92