### PR TITLE
Mention "conformance results for" when !isConformancePR()

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -539,7 +539,7 @@ func handle(log *logrus.Entry, ghc githubClient, pr *suite.PullRequestQuery) err
 		log.Printf("This PR (%v) is not a conformance PR\n", int(pr.Number))
 		finalComment := strings.Join(
 			[]string{
-				"This pull request appears to not be a conformance results submission; Checks will not run.",
+				"This pull request appears to not be a conformance results submission, because its title doesn't include \"conformance results for\"; Checks will not run.",
 				"",
 				"If this change is intended to be verified as a conformance results submission see: " +
 					"[_content of the PR_](https://github.com/cncf/k8s-conformance/blob/master/instructions.md#contents-of-the-pr), " +

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -976,7 +976,7 @@ contact_email_address: "sales@coolkubernetes.com"`,
 			PullRequestQuery: &suite.PullRequestQuery{
 				Title: githubql.String("soup recipes for winter"),
 			},
-			ExpectedComment: "This pull request appears to not be a conformance results submission; Checks will not run.",
+			ExpectedComment: "This pull request appears to not be a conformance results submission, because its title doesn't include \"conformance results for\"; Checks will not run.",
 			ExpectedLabels:  []string{"not-conformance-product-submission", "unable-to-process"},
 			ExpectedStatus:  "pending",
 		},


### PR DESCRIPTION
Bot verifies if a PR is a conformance one by checking if its title includes "conformance results for". However, the bot doesn't mention it in comment, which is not enough for k8s-conformance contributors.