### PR TITLE
Update stable.txt url

### DIFF
--- a/hack/generate-conformanceyaml.sh
+++ b/hack/generate-conformanceyaml.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-K8S_LATEST_VERSION=$(curl -L -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+K8S_LATEST_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
 K8S_LATEST_MINOR_VERSION="$(awk '{split($1,array, "."); print array[2]}' <<<$K8S_LATEST_VERSION)"
 K8S_LAST_MINOR_VERSION=$(($K8S_LATEST_MINOR_VERSION - 2))
 SETS=($(seq $K8S_LAST_MINOR_VERSION $K8S_LATEST_MINOR_VERSION))

--- a/hack/update-stable-txt.sh
+++ b/hack/update-stable-txt.sh
@@ -22,4 +22,4 @@ set -o pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-curl -sSL https://storage.googleapis.com/kubernetes-release/release/stable.txt | tee ./kodata/metadata/stable.txt
+curl -sSL https://dl.k8s.io/release/stable.txt | tee ./kodata/metadata/stable.txt


### PR DESCRIPTION
It looks like we need to update the URL for stable.txt file, the one on the googleapis is supposed to be gone (or not updated automatically any more).

The new URL is: https://dl.k8s.io/release/stable.txt

PS: I will create another PR to update it on kubernetes-sigs/verify-conformance repo as well.

/cc @BobyMCbobs